### PR TITLE
Instead of InvalidOperationException throw ManyGenericSubstitutionsException with details

### DIFF
--- a/GroboContainer/Impl/Exceptions/ManyGenericSubstitutionsException.cs
+++ b/GroboContainer/Impl/Exceptions/ManyGenericSubstitutionsException.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text;
+
+namespace GroboContainer.Impl.Exceptions
+{
+    public class ManyGenericSubstitutionsException : Exception
+    {
+        public ManyGenericSubstitutionsException(Type genericType, Type genericParameterType, Type[] substitutionTypes)
+            : base(
+                string.Format("Параметр {0} типа {1} имеет более 1 типа для подстановки. Типы для подстановки:\r\n{2}",
+                              genericParameterType,
+                              genericType,
+                              Dump(substitutionTypes)
+                    )
+                )
+        {
+        }
+
+        private static string Dump(Type[] substitutionTypes)
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (var substitutionType in substitutionTypes)
+            {
+                stringBuilder.AppendFormat("{0}\r\n", substitutionType.FullName);
+            }
+            return stringBuilder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
During migration to the latest version we found one weird exception:
```
System.InvalidOperationException: Последовательность содержит более одного соответствующего элемента
   в System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   в GroboContainer.Impl.Implementations.TypesHelper.MatchFromGenericConstraints(Type[] arguments, Type[] candidateArguments, Func`2 getImplementations) в
```
There is no useful info to understand what is wrong. 

The PR replaces `InvalidOperationException` with special exception with all additional relevant info inside.