### PR TITLE
Speed up GetImplementationTypes

### DIFF
--- a/GroboContainer.Tests/CoreTests/ContainerTest.cs
+++ b/GroboContainer.Tests/CoreTests/ContainerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using GroboContainer.Core;
 using GroboContainer.Impl;
@@ -18,7 +19,6 @@ namespace GroboContainer.Tests.CoreTests
         public override void SetUp()
         {
             base.SetUp();
-            configuration = NewMock<IContainerConfiguration>();
             internalContainer = NewMock<IInternalContainer>();
             holder = NewMock<IContextHolder>();
             context = NewMock<IInjectionContext>();
@@ -123,7 +123,7 @@ namespace GroboContainer.Tests.CoreTests
         [Test]
         public void TestNoLog()
         {
-            container = new Container(configuration);
+            container = new Container(new TestConfiguration(Enumerable.Empty<Type>()));
             Assert.AreEqual("<no>", container.LastConstructionLog);
         }
 
@@ -138,7 +138,6 @@ namespace GroboContainer.Tests.CoreTests
             Assert.AreEqual("zzz", container.LastConstructionLog);
         }
 
-        private IContainerConfiguration configuration;
         private Container container;
         private IInternalContainer internalContainer;
         private IContextHolder holder;

--- a/GroboContainer.Tests/FunctionalTests/ContainerFunctionalTest.cs
+++ b/GroboContainer.Tests/FunctionalTests/ContainerFunctionalTest.cs
@@ -34,7 +34,7 @@ namespace GroboContainer.Tests.FunctionalTests
         }
 
         [Test]
-        public void TestConstructorAgruments()
+        public void TestConstructorArguments()
         {
             var instance = container.Get<ClassWithArguments>();
             Assert.That(instance, Is.InstanceOf<ClassWithArguments>());
@@ -48,7 +48,7 @@ namespace GroboContainer.Tests.FunctionalTests
         }
 
         [Test]
-        public void TestFuncDependecy()
+        public void TestFuncDependency()
         {
             var instance = container.Get<ClassWithFuncDependecy>();
             Assert.IsInstanceOf<Func<IInterface>>(instance.Dependency);
@@ -60,7 +60,7 @@ namespace GroboContainer.Tests.FunctionalTests
         }
 
         [Test]
-        public void TestLazyDependecy()
+        public void TestLazyDependency()
         {
             var instance = container.Get<ClassWithLazyDependecy>();
             Assert.IsInstanceOf<Lazy<IInterface>>(instance.Dependency);

--- a/GroboContainer.Tests/ImplementationTypesCollectionTest.cs
+++ b/GroboContainer.Tests/ImplementationTypesCollectionTest.cs
@@ -30,50 +30,47 @@ namespace GroboContainer.Tests
             var types = new[] {typeof(int), typeof(long)};
             Type abstractionType = typeof(long);
             Type typeImpl = typeof(long);
-            var collection = new ImplementationTypesCollection(new TestConfiguration(types), helper);
-
+          
             helper.ExpectIsIgnoredImplementation(types[0], false);
             helper.ExpectTryGetImplementation(abstractionType, types[0], null);
 
             helper.ExpectIsIgnoredImplementation(types[1], false);
             helper.ExpectTryGetImplementation(abstractionType, types[1], typeImpl);
 
-            CollectionAssert.AreEquivalent(new[] {typeImpl},
-                                           collection.GetImplementationTypes(abstractionType));
+            var collection = new ImplementationTypesCollection(types, helper);
+            CollectionAssert.AreEquivalent(new[] {typeImpl}, collection.GetImplementationTypes(abstractionType));
         }
 
         [Test]
         public void TestGetGeneric()
         {
             var types = new[] {typeof(int)};
-            Type abstractionType = typeof(I1<int>);
-            Type typeImpl = typeof(Guid);
-            var collection = new ImplementationTypesCollection(new TestConfiguration(types), helper);
-
+            var abstractionType = typeof(I1<int>);
+            var typeImpl = typeof(Guid);
+          
             helper.ExpectIsIgnoredImplementation(types[0], false);
             helper.ExpectTryGetImplementation(abstractionType, types[0], null);
 
-            Type definition = abstractionType.GetGenericTypeDefinition();
+            var definition = abstractionType.GetGenericTypeDefinition();
             helper.ExpectIsIgnoredImplementation(definition, false);
             helper.ExpectTryGetImplementation(abstractionType, definition, typeImpl);
 
-            CollectionAssert.AreEquivalent(new[] {typeImpl},
-                                           collection.GetImplementationTypes(abstractionType));
+            var collection = new ImplementationTypesCollection(types, helper);
+            CollectionAssert.AreEquivalent(new[] {typeImpl}, collection.GetImplementationTypes(abstractionType));
         }
 
         [Test]
-        public void TestGetGenericInCofig()
+        public void TestGetGenericInConfig()
         {
             var types = new[] {typeof(I1<>)};
-            Type abstractionType = typeof(I1<int>);
-            Type typeImpl = abstractionType;
-            var collection = new ImplementationTypesCollection(new TestConfiguration(types), helper);
-
+            var abstractionType = typeof(I1<int>);
+            var typeImpl = abstractionType;
+            
             helper.ExpectIsIgnoredImplementation(types[0], false);
             helper.ExpectTryGetImplementation(abstractionType, types[0], typeImpl);
 
-            CollectionAssert.AreEquivalent(new[] {typeImpl},
-                                           collection.GetImplementationTypes(abstractionType));
+            var collection = new ImplementationTypesCollection(types, helper);
+            CollectionAssert.AreEquivalent(new[] {typeImpl}, collection.GetImplementationTypes(abstractionType));
         }
 
         [Test]
@@ -81,11 +78,12 @@ namespace GroboContainer.Tests
         {
             var types = new[] {typeof(int)};
             Type abstractionType = typeof(long);
-            var collection = new ImplementationTypesCollection(new TestConfiguration(types), helper);
+            
             helper.ExpectIsIgnoredImplementation(types[0], false);
             helper.ExpectTryGetImplementation(abstractionType, types[0], null);
-
             helper.ExpectIsIgnoredImplementation(abstractionType, true);
+
+            var collection = new ImplementationTypesCollection(types, helper);
             CollectionAssert.IsEmpty(collection.GetImplementationTypes(abstractionType));
         }
 

--- a/GroboContainer/Impl/ChildContainersSupport/CompositeContainerContext.cs
+++ b/GroboContainer/Impl/ChildContainersSupport/CompositeContainerContext.cs
@@ -1,4 +1,4 @@
-﻿using GroboContainer.Core;
+using GroboContainer.Core;
 using GroboContainer.Impl.Abstractions;
 using GroboContainer.Impl.Abstractions.AutoConfiguration;
 using GroboContainer.Impl.ChildContainersSupport.Selectors;
@@ -23,7 +23,7 @@ namespace GroboContainer.Impl.ChildContainersSupport
             var constructorSelector = new ConstructorSelector();
             CreationContext = new CreationContext(classCreator, constructorSelector, classWrapperCreator);
 
-            var implementationTypesCollection = new ImplementationTypesCollection(configuration, typesHelper);
+            var implementationTypesCollection = new ImplementationTypesCollection(configuration.GetTypesToScan(), typesHelper);
             ImplementationCache = new ImplementationCache();
             abstractionsCollection = new AbstractionsCollection(implementationTypesCollection, ImplementationCache);
             ImplementationConfigurationCache = new ImplementationConfigurationCache();

--- a/GroboContainer/Impl/ContainerContext.cs
+++ b/GroboContainer/Impl/ContainerContext.cs
@@ -15,7 +15,7 @@ namespace GroboContainer.Impl
         {
             this.Configuration = configuration;
             ClassWrapperCreator = classWrapperCreator;
-            typesHelper = new TypesHelper();
+            ITypesHelper typesHelper = new TypesHelper();
 
             var funcHelper = new FuncHelper();
             FuncBuilder = new FuncBuilder();
@@ -23,9 +23,9 @@ namespace GroboContainer.Impl
             var constructorSelector = new ConstructorSelector();
             CreationContext = new CreationContext(classCreator, constructorSelector, classWrapperCreator);
 
-            var implementationTypesCollection = new ImplementationTypesCollection(configuration, typesHelper);
+            var implementationTypesCollection = new ImplementationTypesCollection(configuration.GetTypesToScan(), typesHelper);
             ImplementationCache = new ImplementationCache();
-            abstractionsCollection = new AbstractionsCollection(implementationTypesCollection, ImplementationCache); //g
+            IAbstractionsCollection abstractionsCollection = new AbstractionsCollection(implementationTypesCollection, ImplementationCache);
             ImplementationConfigurationCache = new ImplementationConfigurationCache(); //l
             var factory = new AutoAbstractionConfigurationFactory(typesHelper, abstractionsCollection, ImplementationConfigurationCache);
             AbstractionConfigurationCollection = new AbstractionConfigurationCollection(factory);
@@ -35,8 +35,6 @@ namespace GroboContainer.Impl
         public IClassWrapperCreator ClassWrapperCreator { get; private set; }
         public IImplementationConfigurationCache ImplementationConfigurationCache { get; private set; }
         public IImplementationCache ImplementationCache { get; private set; }
-        private readonly IAbstractionsCollection abstractionsCollection;
-        private readonly ITypesHelper typesHelper;
 
         #region IContainerContext Members
 


### PR DESCRIPTION
PR tries to speedup the `ImplementationTypesCollection.GetImplementationTypes`.

It uses `Type.IsDefined` to check if a type is ignorable implementation or not.

Here is the benchmark which checks N(in our case N is 25090) types for `Type.IsDefined`:
```
using System.Runtime.Serialization;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace Attributes
{
    public class EntyPoint
    {
        public static void Main()
        {
            BenchmarkRunner.Run<Attributes>();
        }
    }

    [DataContract]
    public class A
    {
    }

    [ClrJob]
    public class Attributes
    {
        [Benchmark]
        public int IsDefined()
        {
            var count = 0;
            for (var i = 0; i < 25090; ++i) count += typeof(A).IsDefined(typeof(DataContractAttribute), false) ? 1 : 0;
            return count;
        }
    }
}
```

Here is the result:
```
BenchmarkDotNet=v0.11.2, OS=Windows 10.0.17134.345 (1803/April2018Update/Redstone4)
Intel Xeon Processor (Skylake, IBRS), 1 CPU, 2 logical and 2 physical cores
  [Host] : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3190.0
  Clr    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3190.0

Job=Clr  Runtime=Clr

    Method |     Mean |     Error |   StdDev |
---------- |---------:|----------:|---------:|
 IsDefined | 39.66 ms | 0.9180 ms | 2.678 ms |
```

For every first resolve of the abstraction(it's actually every interface and in our case we have a lot of interfaces) needs at least 40ms only for `Type.IsDefined` calls.

PS Also `Type.IsDefined` produces a lot of allocations:
![image](https://user-images.githubusercontent.com/664889/48479876-a5e6e880-e819-11e8-8fe5-16d43d3e1a72.png)


