### PR TITLE
Custom instance creation func

### DIFF
--- a/GroboContainer.Tests/AbstractionTests/AbstractionConfigurationCollectionTest.cs
+++ b/GroboContainer.Tests/AbstractionTests/AbstractionConfigurationCollectionTest.cs
@@ -99,6 +99,20 @@ namespace GroboContainer.Tests.AbstractionTests
             Assert.AreSame(configuration2, actualConfiguration);
         }
 
+        [Test]
+        public void TestUnableReconfigureParametrizedGenericWhenAlreadyRequested()
+        {
+            var configuration = GetMock<IAbstractionConfiguration>();
+            configuration.Expect(c => c.GetImplementations())
+                         .Return(new IImplementationConfiguration[] {new InstanceImplementationConfiguration(null, 1)});
+            configurationCollection.Add(typeof(Nullable<>), configuration);
+            var _ = configurationCollection.Get(typeof(int?));
+            var otherConfiguration = NewMock<IAbstractionConfiguration>();
+            RunMethodWithException<InvalidOperationException>(
+                () => configurationCollection.Add(typeof(int?), otherConfiguration),
+                "Container is already configured for type System.Nullable`1[System.Int32]");
+        }
+
         private IAutoAbstractionConfigurationFactory factory;
         private AbstractionConfigurationCollection configurationCollection;
     }

--- a/GroboContainer.Tests/AbstractionTests/AbstractionConfigurationCollectionTest.cs
+++ b/GroboContainer.Tests/AbstractionTests/AbstractionConfigurationCollectionTest.cs
@@ -79,6 +79,26 @@ namespace GroboContainer.Tests.AbstractionTests
                                            configurationCollection.GetAll());
         }
 
+        [Test]
+        public void TestGetParametrizedGenericWhenNotParametrizedRegistered()
+        {
+            var configuration = NewMock<IAbstractionConfiguration>();
+            configurationCollection.Add(typeof(Nullable<>), configuration);
+            var actualConfiguration = configurationCollection.Get(typeof(int?));
+            Assert.AreSame(configuration, actualConfiguration);
+        }
+
+        [Test]
+        public void TestMorePreciseRegistrationUsedForGenericTypesRegistration()
+        {
+            var configuration1 = NewMock<IAbstractionConfiguration>();
+            var configuration2 = NewMock<IAbstractionConfiguration>();
+            configurationCollection.Add(typeof(Nullable<>), configuration1);
+            configurationCollection.Add(typeof(int?), configuration2);
+            var actualConfiguration = configurationCollection.Get(typeof(int?));
+            Assert.AreSame(configuration2, actualConfiguration);
+        }
+
         private IAutoAbstractionConfigurationFactory factory;
         private AbstractionConfigurationCollection configurationCollection;
     }

--- a/GroboContainer.Tests/FunctionalTests/UseFactoryFuncTests.cs
+++ b/GroboContainer.Tests/FunctionalTests/UseFactoryFuncTests.cs
@@ -47,15 +47,6 @@ namespace GroboContainer.Tests.FunctionalTests
         }
 
         [Test]
-        public void TestFactoryResultNotCached()
-        {
-            container.Configurator.ForAbstraction<SimpleClass>().UseFactory((c, t) => new SimpleClass());
-            var instance1 = container.Get<SimpleClass>();
-            var instance2 = container.Get<SimpleClass>();
-            Assert.AreNotSame(instance1, instance2);
-        }
-
-        [Test]
         public void TestCouldResolveAlreadyRegisteredInFactory()
         {
             var expectedString = Guid.NewGuid().ToString();

--- a/GroboContainer.Tests/FunctionalTests/UseFactoryFuncTests.cs
+++ b/GroboContainer.Tests/FunctionalTests/UseFactoryFuncTests.cs
@@ -1,0 +1,85 @@
+using System;
+
+using NUnit.Framework;
+
+namespace GroboContainer.Tests.FunctionalTests
+{
+    public class UseFactoryFuncTests : ContainerTestBase
+    {
+        [Test]
+        public void TestSimpleGenericAbstractionConfiguration()
+        {
+            var expectedInstance = new SimpleClass();
+            container.Configurator.ForAbstraction<SimpleClass>().UseFactory((c, t) => expectedInstance);
+            var instance = container.Get<SimpleClass>();
+            Assert.AreSame(expectedInstance, instance);
+        }
+
+        [Test]
+        public void TestSimpleNonGenericAbstractionConfiguration()
+        {
+            var expectedInstance = new SimpleClass();
+            container.Configurator.ForAbstraction(typeof(SimpleClass)).UseFactory((c, t) => expectedInstance);
+            var instance = container.Get<SimpleClass>();
+            Assert.AreSame(expectedInstance, instance);
+        }
+
+        [Test]
+        public void TestGenericClassGenericAbstractionConfiguration()
+        {
+            var expectedInstance = new GenericClass<SimpleClass>();
+            container.Configurator.ForAbstraction<GenericClass<SimpleClass>>().UseFactory((c, t) => expectedInstance);
+            var instance = container.Get<GenericClass<SimpleClass>>();
+            Assert.AreSame(expectedInstance, instance);
+        }
+
+        [Test]
+        public void TestActualRequestedTypePassedToFactory()
+        {
+            var expectedInstance = new GenericClass<SimpleClass>();
+            container.Configurator.ForAbstraction(typeof(IGenericInterface<>)).UseFactory((c, t) =>
+                {
+                    Assert.AreSame(t, typeof(IGenericInterface<SimpleClass>));
+                    return expectedInstance;
+                });
+            var instance = container.Get<IGenericInterface<SimpleClass>>();
+            Assert.AreSame(expectedInstance, instance);
+        }
+
+        [Test]
+        public void TestFactoryResultNotCached()
+        {
+            container.Configurator.ForAbstraction<SimpleClass>().UseFactory((c, t) => new SimpleClass());
+            var instance1 = container.Get<SimpleClass>();
+            var instance2 = container.Get<SimpleClass>();
+            Assert.AreNotSame(instance1, instance2);
+        }
+
+        [Test]
+        public void TestCouldResolveAlreadyRegisteredInFactory()
+        {
+            var expectedString = Guid.NewGuid().ToString();
+            container.Configurator.ForAbstraction<string>().UseInstances(expectedString);
+            container.Configurator.ForAbstraction<SimpleClass>().UseFactory((c, t) =>
+                {
+                    var s = container.Get<string>();
+                    return new SimpleClass {Value = s};
+                });
+            var instance = container.Get<SimpleClass>();
+            Assert.AreEqual(expectedString, instance.Value);
+        }
+
+        private interface IGenericInterface<T>
+        {
+        }
+
+        private class SimpleClass
+        {
+            public string Value { get; set; }
+        }
+
+        private class GenericClass<T> : IGenericInterface<T>
+        {
+        }
+    }
+}

--- a/GroboContainer.Tests/ImplTests/ImplementationTests/ContainerImplementationConfigurationTest.cs
+++ b/GroboContainer.Tests/ImplTests/ImplementationTests/ContainerImplementationConfigurationTest.cs
@@ -40,7 +40,7 @@ namespace GroboContainer.Tests.ImplTests.ImplementationTests
             var container = NewMock<IContainer>();
             context.ExpectGetContainer(container);
             context.ExpectReused(typeof(IContainer));
-            Assert.AreSame(container, configuration.GetOrCreateInstance(context, null));
+            Assert.AreSame(container, configuration.GetOrCreateInstance(context, null, typeof(IContainer)));
         }
 
         private ContainerImplementationConfiguration configuration;

--- a/GroboContainer.Tests/ImplTests/ImplementationTests/FactoryImplementationConfigurationTests.cs
+++ b/GroboContainer.Tests/ImplTests/ImplementationTests/FactoryImplementationConfigurationTests.cs
@@ -1,0 +1,93 @@
+using System;
+
+using GroboContainer.Impl.Implementations;
+using GroboContainer.Impl.Injection;
+using GroboContainer.New;
+
+using NUnit.Framework;
+
+using Rhino.Mocks;
+
+namespace GroboContainer.Tests.ImplTests.ImplementationTests
+{
+    public class FactoryImplementationConfigurationTests : CoreTestBase
+    {
+        [Test]
+        public void TestDisposeCalledOnAllInstances()
+        {
+            var disposable1 = GetMock<ITestGeneric<int>>();
+            var disposable2 = GetMock<ITestGeneric<string>>();
+            var configuration = new FactoryImplementationConfiguration(typeof(ITestGeneric<>), (container, type) =>
+                {
+                    if (type == typeof(ITestGeneric<int>))
+                        return disposable1;
+                    if (type == typeof(ITestGeneric<string>))
+                        return disposable2;
+                    throw new AssertionException("Unexpected type requested");
+                });
+
+            var injectionContext = NewMock<IInjectionContext>();
+            var creationContext = NewMock<ICreationContext>();
+            injectionContext.ExpectGetContainer(null);
+            configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
+            injectionContext.ExpectGetContainer(null);
+            configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
+
+            disposable1.Expect(d => d.Dispose()).Repeat.Once();
+            disposable2.Expect(d => d.Dispose()).Repeat.Once();
+
+            configuration.DisposeInstance();
+        }
+
+        [Test]
+        public void TestResolvedCached()
+        {
+            var configuration = new FactoryImplementationConfiguration(typeof(object), (container, type) => new object());
+            var injectionContext = NewMock<IInjectionContext>();
+            var creationContext = NewMock<ICreationContext>();
+            injectionContext.ExpectGetContainer(null);
+            var instance1 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(object));
+            injectionContext.ExpectReused(typeof(object));
+            var instance2 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(object));
+
+            Assert.AreSame(instance1, instance2);
+        }
+
+        [Test]
+        public void TestResolvedCachedPerConcreteType()
+        {
+            var expectedCached1 = GetMock<ITestGeneric<int>>();
+            var expectedCached2 = GetMock<ITestGeneric<string>>();
+            var configuration = new FactoryImplementationConfiguration(typeof(ITestGeneric<>), (container, type) =>
+                {
+                    if (type == typeof(ITestGeneric<int>))
+                        return expectedCached1;
+                    if (type == typeof(ITestGeneric<string>))
+                        return expectedCached2;
+                    throw new AssertionException("Unexpected type requested");
+                });
+
+            var injectionContext = NewMock<IInjectionContext>();
+            var creationContext = NewMock<ICreationContext>();
+            injectionContext.ExpectGetContainer(null);
+            var actualInstance1 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
+            injectionContext.ExpectReused(typeof(ITestGeneric<int>));
+            var actualInstance2 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
+            Assert.AreSame(actualInstance1, actualInstance2);
+            Assert.AreSame(expectedCached1, actualInstance1);
+            
+            injectionContext.ExpectGetContainer(null);
+            var actualInstance3 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
+            injectionContext.ExpectReused(typeof(ITestGeneric<string>));
+            var actualInstance4 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
+
+            Assert.AreSame(actualInstance3, actualInstance4);
+            Assert.AreSame(expectedCached2, actualInstance3);
+        }
+
+        // ReSharper disable once MemberCanBePrivate.Global
+        public interface ITestGeneric<T> : IDisposable
+        {
+        }
+    }
+}

--- a/GroboContainer.Tests/ImplTests/ImplementationTests/FactoryImplementationConfigurationTests.cs
+++ b/GroboContainer.Tests/ImplTests/ImplementationTests/FactoryImplementationConfigurationTests.cs
@@ -28,9 +28,9 @@ namespace GroboContainer.Tests.ImplTests.ImplementationTests
 
             var injectionContext = NewMock<IInjectionContext>();
             var creationContext = NewMock<ICreationContext>();
-            injectionContext.ExpectGetContainer(null);
+            ExpectConstruction(injectionContext, typeof(ITestGeneric<int>));
             configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
-            injectionContext.ExpectGetContainer(null);
+            ExpectConstruction(injectionContext, typeof(ITestGeneric<string>));
             configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
 
             disposable1.Expect(d => d.Dispose()).Repeat.Once();
@@ -45,7 +45,7 @@ namespace GroboContainer.Tests.ImplTests.ImplementationTests
             var configuration = new FactoryImplementationConfiguration(typeof(object), (container, type) => new object());
             var injectionContext = NewMock<IInjectionContext>();
             var creationContext = NewMock<ICreationContext>();
-            injectionContext.ExpectGetContainer(null);
+            ExpectConstruction(injectionContext, typeof(object));
             var instance1 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(object));
             injectionContext.ExpectReused(typeof(object));
             var instance2 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(object));
@@ -69,20 +69,27 @@ namespace GroboContainer.Tests.ImplTests.ImplementationTests
 
             var injectionContext = NewMock<IInjectionContext>();
             var creationContext = NewMock<ICreationContext>();
-            injectionContext.ExpectGetContainer(null);
+            ExpectConstruction(injectionContext, typeof(ITestGeneric<int>));
             var actualInstance1 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
             injectionContext.ExpectReused(typeof(ITestGeneric<int>));
             var actualInstance2 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<int>));
             Assert.AreSame(actualInstance1, actualInstance2);
             Assert.AreSame(expectedCached1, actualInstance1);
-            
-            injectionContext.ExpectGetContainer(null);
+
+            ExpectConstruction(injectionContext, typeof(ITestGeneric<string>));
             var actualInstance3 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
             injectionContext.ExpectReused(typeof(ITestGeneric<string>));
             var actualInstance4 = configuration.GetOrCreateInstance(injectionContext, creationContext, typeof(ITestGeneric<string>));
 
             Assert.AreSame(actualInstance3, actualInstance4);
             Assert.AreSame(expectedCached2, actualInstance3);
+        }
+
+        private static void ExpectConstruction(IInjectionContext injectionContext, Type constructedType)
+        {
+            injectionContext.ExpectGetContainer(null);
+            injectionContext.ExpectBeginConstruct(constructedType);
+            injectionContext.ExpectEndConstruct(constructedType);
         }
 
         // ReSharper disable once MemberCanBePrivate.Global

--- a/GroboContainer.Tests/ImplTests/ImplementationTests/InstanceImplementationConfigurationTest.cs
+++ b/GroboContainer.Tests/ImplTests/ImplementationTests/InstanceImplementationConfigurationTest.cs
@@ -41,7 +41,7 @@ namespace GroboContainer.Tests.ImplTests.ImplementationTests
             var configuration = new InstanceImplementationConfiguration(new TestClassWrapperCreator(), instance);
             var context = NewMock<IInjectionContext>();
             context.ExpectReused(instance.GetType());
-            Assert.AreSame(instance, configuration.GetOrCreateInstance(context, null));
+            Assert.AreSame(instance, configuration.GetOrCreateInstance(context, null, typeof(object)));
         }
     }
 }

--- a/GroboContainer.Tests/ImplTests/InternalContainerTest.cs
+++ b/GroboContainer.Tests/ImplTests/InternalContainerTest.cs
@@ -159,7 +159,7 @@ namespace GroboContainer.Tests.ImplTests
             var result = new object[] {"xss"};
             abstractionConfiguration.ExpectGetImplementations(implementationConfiguration);
             implementationConfiguration[0].Expect(
-                configuration1 => configuration1.GetOrCreateInstance(context, creationContext)).Return("xss");
+                configuration1 => configuration1.GetOrCreateInstance(context, creationContext, type)).Return("xss");
 
             context.ExpectEndGet(type);
             ordered.Dispose();
@@ -180,9 +180,9 @@ namespace GroboContainer.Tests.ImplTests
                 };
             abstractionConfiguration.ExpectGetImplementations(implementationConfiguration);
             implementationConfiguration[0].Expect(
-                c => c.GetOrCreateInstance(context, creationContext)).Return(1);
+                c => c.GetOrCreateInstance(context, creationContext, type)).Return(1);
             implementationConfiguration[1].Expect(
-                c => c.GetOrCreateInstance(context, creationContext)).Return(2);
+                c => c.GetOrCreateInstance(context, creationContext, type)).Return(2);
             context.ExpectEndGetAll(type);
             ordered.Dispose();
             CollectionAssert.AreEqual(new object[] {1, 2}, internalContainer.GetAll(type, context));

--- a/GroboContainer.Tests/NewTests/AutoImplementationConfigurationTest.cs
+++ b/GroboContainer.Tests/NewTests/AutoImplementationConfigurationTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using GroboContainer.Impl.Abstractions.AutoConfiguration;
 using GroboContainer.Impl.ClassCreation;
@@ -39,19 +39,19 @@ namespace GroboContainer.Tests.NewTests
             implementation.Expect(context => context.GetFactory(Type.EmptyTypes, creationContext)).Return(classFactory);
             var instance = GetMock<IDisposable>();
             classFactory.Expect(f => f.Create(injectionContext, new object[0])).Return(instance);
-            var returnedInstance = autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext);
+            var returnedInstance = autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType());
             Assert.AreSame(instance, returnedInstance);
 
             injectionContext.Expect(ic => ic.Reused(typeof(int)));
             Assert.AreSame(instance,
-                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext));
+                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType()));
 
             instance.Expect(i => i.Dispose());
             autoImplementationConfiguration.DisposeInstance();
 
             injectionContext.Expect(ic => ic.Reused(typeof(int)));
             Assert.AreSame(instance,
-                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext));
+                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType()));
 
             instance.Expect(i => i.Dispose());
             autoImplementationConfiguration.DisposeInstance();
@@ -96,18 +96,18 @@ namespace GroboContainer.Tests.NewTests
             implementation.Expect(context => context.GetFactory(Type.EmptyTypes, creationContext)).Return(classFactory);
             const string instance = "zzz";
             classFactory.Expect(f => f.Create(injectionContext, new object[0])).Return(instance);
-            var returnedInstance = autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext);
+            var returnedInstance = autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType());
             Assert.AreSame(instance, returnedInstance);
 
             injectionContext.Expect(ic => ic.Reused(typeof(int)));
             Assert.AreSame(instance,
-                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext));
+                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType()));
 
             autoImplementationConfiguration.DisposeInstance();
 
             injectionContext.Expect(ic => ic.Reused(typeof(int)));
             Assert.AreSame(instance,
-                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext));
+                           autoImplementationConfiguration.GetOrCreateInstance(injectionContext, creationContext, implementation.GetType()));
         }
 
         private IImplementation implementation;

--- a/GroboContainer/Config/AbstractionConfigurator.cs
+++ b/GroboContainer/Config/AbstractionConfigurator.cs
@@ -62,6 +62,12 @@ namespace GroboContainer.Config
             abstractionConfigurationCollection.Add(abstractionType, abstractionConfiguration);
         }
 
+        public void UseFactory(Func<IContainer, Type, object> factoryFunc)
+        {
+            var abstractionConfiguration = new FactoryAbstractionConfiguration(abstractionType, factoryFunc);
+            abstractionConfigurationCollection.Add(abstractionType, abstractionConfiguration);
+        }
+
         #endregion
     }
 }

--- a/GroboContainer/Config/Generic/AbstractionConfigurator.cs
+++ b/GroboContainer/Config/Generic/AbstractionConfigurator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using GroboContainer.Core;
@@ -30,6 +31,11 @@ namespace GroboContainer.Config.Generic
         {
             var objects = instances.Cast<object>().ToArray();
             worker.UseInstances(objects);
+        }
+
+        public void UseFactory<TImpl>(Func<IContainer, Type, TImpl> factoryFunc) where TImpl : T
+        {
+            worker.UseFactory((container, type) => factoryFunc(container, type));
         }
 
         public void Fail()

--- a/GroboContainer/Config/Generic/IAbstractionConfigurator.cs
+++ b/GroboContainer/Config/Generic/IAbstractionConfigurator.cs
@@ -1,3 +1,7 @@
+using System;
+
+using GroboContainer.Core;
+
 namespace GroboContainer.Config.Generic
 {
     public interface IAbstractionConfigurator<in T>
@@ -5,5 +9,6 @@ namespace GroboContainer.Config.Generic
         void UseInstances(params T[] instances);
         void Fail();
         void UseType<TImpl>() where TImpl : T;
+        void UseFactory<TImpl>(Func<IContainer, Type, TImpl> factoryFunc) where TImpl : T;
     }
 }

--- a/GroboContainer/Config/IAbstractionConfigurator.cs
+++ b/GroboContainer/Config/IAbstractionConfigurator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+
+using GroboContainer.Core;
 
 namespace GroboContainer.Config
 {
@@ -8,5 +10,6 @@ namespace GroboContainer.Config
         void Fail();
         void UseType(Type type);
         void UseTypes(Type[] types);
+        void UseFactory(Func<IContainer, Type, object> factoryFunc);
     }
 }

--- a/GroboContainer/Impl/Abstractions/AbstractionConfigurationCollection.cs
+++ b/GroboContainer/Impl/Abstractions/AbstractionConfigurationCollection.cs
@@ -18,8 +18,8 @@ namespace GroboContainer.Impl.Abstractions
             if (abstractionType.IsGenericType && !cache.ContainsKey(abstractionType))
             {
                 var genericTypeDefinition = abstractionType.GetGenericTypeDefinition();
-                if (cache.ContainsKey(genericTypeDefinition))
-                    return cache[genericTypeDefinition];
+                if (cache.TryGetValue(genericTypeDefinition, out var configuration))
+                    return cache.GetOrAdd(abstractionType, configuration);
             }
 
             return cache.GetOrAdd(abstractionType, createByType);

--- a/GroboContainer/Impl/Abstractions/AbstractionConfigurationCollection.cs
+++ b/GroboContainer/Impl/Abstractions/AbstractionConfigurationCollection.cs
@@ -15,6 +15,13 @@ namespace GroboContainer.Impl.Abstractions
 
         public IAbstractionConfiguration Get(Type abstractionType)
         {
+            if (abstractionType.IsGenericType && !cache.ContainsKey(abstractionType))
+            {
+                var genericTypeDefinition = abstractionType.GetGenericTypeDefinition();
+                if (cache.ContainsKey(genericTypeDefinition))
+                    return cache[genericTypeDefinition];
+            }
+
             return cache.GetOrAdd(abstractionType, createByType);
         }
 

--- a/GroboContainer/Impl/Abstractions/AutoConfiguration/AutoImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Abstractions/AutoConfiguration/AutoImplementationConfiguration.cs
@@ -16,7 +16,7 @@ namespace GroboContainer.Impl.Abstractions.AutoConfiguration
 
         public Type ObjectType => implementation.ObjectType;
 
-        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext)
+        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType)
         {
             if (instance == null)
             {

--- a/GroboContainer/Impl/Abstractions/FactoryAbstractionConfiguration.cs
+++ b/GroboContainer/Impl/Abstractions/FactoryAbstractionConfiguration.cs
@@ -1,0 +1,22 @@
+using System;
+
+using GroboContainer.Core;
+using GroboContainer.Impl.Implementations;
+
+namespace GroboContainer.Impl.Abstractions
+{
+    public class FactoryAbstractionConfiguration : IAbstractionConfiguration
+    {
+        public FactoryAbstractionConfiguration(Type objectType, Func<IContainer, Type, object> factoryFunc)
+        {
+            implementationConfigurations = new IImplementationConfiguration[]
+                {
+                    new FactoryImplementationConfiguration(objectType, factoryFunc)
+                };
+        }
+
+        public IImplementationConfiguration[] GetImplementations() => implementationConfigurations;
+
+        private readonly IImplementationConfiguration[] implementationConfigurations;
+    }
+}

--- a/GroboContainer/Impl/Implementations/ContainerImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Implementations/ContainerImplementationConfiguration.cs
@@ -11,7 +11,7 @@ namespace GroboContainer.Impl.Implementations
     {
         public Type ObjectType => typeof(Container);
 
-        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext)
+        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType)
         {
             context.Reused(typeof(IContainer));
             return context.Container;

--- a/GroboContainer/Impl/Implementations/FactoryImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Implementations/FactoryImplementationConfiguration.cs
@@ -1,0 +1,37 @@
+using System;
+
+using GroboContainer.Core;
+using GroboContainer.Impl.ClassCreation;
+using GroboContainer.Impl.Injection;
+using GroboContainer.New;
+
+namespace GroboContainer.Impl.Implementations
+{
+    public class FactoryImplementationConfiguration : IImplementationConfiguration
+    {
+        public FactoryImplementationConfiguration(Type objectType, Func<IContainer, Type, object> factoryFunc)
+        {
+            ObjectType = objectType ?? throw new ArgumentNullException(nameof(objectType));
+            this.factoryFunc = factoryFunc ?? throw new ArgumentNullException(nameof(factoryFunc));
+        }
+
+        public Type ObjectType { get; }
+
+        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType)
+        {
+            return factoryFunc(context.Container, requestedType);
+        }
+
+        public void DisposeInstance()
+        {
+            // no instance is managed by container
+        }
+
+        public IClassFactory GetFactory(Type[] parameterTypes, ICreationContext creationContext)
+        {
+            throw new NotSupportedException();
+        }
+
+        private readonly Func<IContainer, Type, object> factoryFunc;
+    }
+}

--- a/GroboContainer/Impl/Implementations/ForbiddenImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Implementations/ForbiddenImplementationConfiguration.cs
@@ -16,7 +16,7 @@ namespace GroboContainer.Impl.Implementations
 
         public Type ObjectType => throw new ForbiddenAbstractionException(abstractionType);
 
-        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext)
+        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType)
         {
             throw new ForbiddenAbstractionException(abstractionType);
         }

--- a/GroboContainer/Impl/Implementations/IImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Implementations/IImplementationConfiguration.cs
@@ -9,7 +9,7 @@ namespace GroboContainer.Impl.Implementations
     public interface IImplementationConfiguration
     {
         Type ObjectType { get; }
-        object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext);
+        object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType);
         void DisposeInstance();
         IClassFactory GetFactory(Type[] parameterTypes, ICreationContext creationContext);
     }

--- a/GroboContainer/Impl/Implementations/InstanceImplementationConfiguration.cs
+++ b/GroboContainer/Impl/Implementations/InstanceImplementationConfiguration.cs
@@ -21,7 +21,7 @@ namespace GroboContainer.Impl.Implementations
 
         public Type ObjectType { get; }
 
-        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext)
+        public object GetOrCreateInstance(IInjectionContext context, ICreationContext creationContext, Type requestedType)
         {
             context.Reused(ObjectType);
             return instance;

--- a/GroboContainer/Impl/InternalContainer.cs
+++ b/GroboContainer/Impl/InternalContainer.cs
@@ -69,7 +69,7 @@ namespace GroboContainer.Impl
             var implementations = GetImplementations(abstractionType);
             var result = new T[implementations.Length];
             for (var i = 0; i < result.Length; i++)
-                result[i] = (T)UnWrap(abstractionType, implementations[i].GetOrCreateInstance(context, creationContext));
+                result[i] = (T)UnWrap(abstractionType, implementations[i].GetOrCreateInstance(context, creationContext, abstractionType));
             return result;
         }
 
@@ -184,7 +184,7 @@ namespace GroboContainer.Impl
             {
                 context.BeginGet(type);
                 var configuration = GetSingleImplementation(type);
-                return UnWrap(type, configuration.GetOrCreateInstance(context, creationContext));
+                return UnWrap(type, configuration.GetOrCreateInstance(context, creationContext, type));
             }
             catch (Exception)
             {


### PR DESCRIPTION
Иногда хочется специальным образом создавать объекты, конструктор которых нельзя поправить (например, из внешней библиотеки). Добавил фичу 
```csharp
container.Configurator.ForAbstraction(...).UseFactory(...)
```
Теперь можно один раз написать способ создания и потом просить из контейнера.
Также добавил возможность регистрировать и непараметризованные дженерики, чтобы можно было одну фабрику на всех зарегистрировать.